### PR TITLE
fix https://github.com/Enngage/ngx-paypal/issues/57

### DIFF
--- a/projects/ngx-paypal-lib/src/lib/components/paypal.component.ts
+++ b/projects/ngx-paypal-lib/src/lib/components/paypal.component.ts
@@ -41,8 +41,6 @@ import {PayPalScriptService} from '../services/paypal-script.service';
 })
 export class NgxPaypalComponent implements OnChanges, OnDestroy, AfterViewInit {
 
-  @Input()
-  divId: number | undefined;
   /**
    * Configuration for PayPal.
    */


### PR DESCRIPTION
using new Date().valueOf() creates the same id as the components are generated at the very same time.